### PR TITLE
refactor: use api.nyk.io as api url

### DIFF
--- a/source/scripts/popup.js
+++ b/source/scripts/popup.js
@@ -188,7 +188,7 @@ async function retrieveSnykInformation({ snykApiToken }) {
     )
     $('#healthscore iframe').prop('src', scoreUrl)
 
-    const url = `https://snyk.io/api/v1/test/npm/${response.packageName}/${response.packageVersion}`
+    const url = `https://api.snyk.io/v1/test/npm/${response.packageName}/${response.packageVersion}`
     try {
       const vulnerabilitiesData = await fetch(url, {
         headers: {


### PR DESCRIPTION
`snyk.io/api` is the legacy and deprecated way to access Snyk APIs. Let's use `api.snyk.io` instead.